### PR TITLE
First implementation of lifecycle planner

### DIFF
--- a/src/ur10_moveit_config/config/ur10_with_custom_ee.srdf
+++ b/src/ur10_moveit_config/config/ur10_with_custom_ee.srdf
@@ -16,6 +16,7 @@
         <joint name="wrist_1_joint"/>
         <joint name="wrist_2_joint"/>
         <joint name="wrist_3_joint"/>
+        <link name="custom_ee_link"/>
     </group>
     <group name="welding_torch">
         <joint name="custom_ee_joint"/>

--- a/src/ur10_moveit_config/config/ur10_with_custom_ee.srdf
+++ b/src/ur10_moveit_config/config/ur10_with_custom_ee.srdf
@@ -16,6 +16,8 @@
         <joint name="wrist_1_joint"/>
         <joint name="wrist_2_joint"/>
         <joint name="wrist_3_joint"/>
+    </group>
+    <group name="welding_torch">
         <joint name="custom_ee_joint"/>
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
@@ -36,7 +38,7 @@
         <joint name="wrist_3_joint" value="0"/>
     </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
-    <end_effector name="welding_torch_end_effector" parent_link="tool0" group="arm"/>
+    <end_effector name="welding_torch_end_effector" parent_link="custom_ee_link" group="arm" parent_group="welding_torch"/>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="virtual_joint" type="fixed" parent_frame="world" child_link="base_link"/>
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->

--- a/src/ur10_moveit_config/launch/ur10_gazebo_moveit.launch.py
+++ b/src/ur10_moveit_config/launch/ur10_gazebo_moveit.launch.py
@@ -90,6 +90,19 @@ def generate_launch_description():
         ],
     )
 
+    # Step 9: Launch lifecycle planner node
+    lifecycle_planner_node = Node(
+        package="ur10_planner",
+        executable="lifecycle_planner",
+        name="lifecycle_planner",
+        output="screen",
+        emulate_tty=True,
+        parameters=[
+            moveit_config.to_dict(),
+            {"use_sim_time": True},
+        ],
+    )
+
     return LaunchDescription([
         gazebo,
         clock_bridge,
@@ -98,4 +111,5 @@ def generate_launch_description():
         spawn_controllers,
         move_group_node,
         rviz_node,
+        lifecycle_planner_node,
     ])

--- a/src/ur10_planner/CMakeLists.txt
+++ b/src/ur10_planner/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.8)
+project(ur10_planner)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(moveit_ros_move_group REQUIRED)
+find_package(moveit_ros_planning_interface REQUIRED)
+find_package(moveit_msgs REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+
+add_executable(lifecycle_planner src/lifecycle_planner.cpp)
+ament_target_dependencies(
+  lifecycle_planner
+  rclcpp
+  rclcpp_lifecycle
+  std_msgs
+  moveit_ros_move_group
+  moveit_ros_planning_interface
+  moveit_msgs
+  moveit_visual_tools
+)
+
+install(
+  TARGETS lifecycle_planner
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/src/ur10_planner/LICENSE
+++ b/src/ur10_planner/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/ur10_planner/package.xml
+++ b/src/ur10_planner/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ur10_planner</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="olmosbryant@outlook.com">bryant</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>std_msgs</depend>
+  <depend>moveit_ros_move_group</depend>
+  <depend>moveit_ros_planning_interface</depend>
+  <depend>moveit_msgs</depend>
+  <depend>moveit_visual_tools</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/ur10_planner/src/lifecycle_planner copy.cpp
+++ b/src/ur10_planner/src/lifecycle_planner copy.cpp
@@ -1,0 +1,58 @@
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+// LCR = Lifecycle Callback Return
+using LCR = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+class lifecycle_planner : public rclcpp_lifecycle::LifecycleNode {
+    public:
+        lifecycle_planner(): LifecycleNode("lifecycle_planner") {
+            RCLCPP_INFO(this->get_logger(), "In constructor ... waiting for next step");
+        }
+
+        LCR on_configure(const rclcpp_lifecycle::State &previous_state) {
+            (void)previous_state;
+            RCLCPP_INFO(this->get_logger(), "IN **ON_CONFIGURE**");
+
+            return LCR::SUCCESS;
+        };
+
+        LCR on_activate(const rclcpp_lifecycle::State &previous_state) {
+            RCLCPP_INFO(this->get_logger(), "IN **ON_ACTIVATE**");
+            rclcpp_lifecycle::LifecycleNode::on_activate(previous_state);
+
+            return LCR::SUCCESS;
+        };
+
+        LCR on_deactivate(const rclcpp_lifecycle::State &previous_state) {
+            RCLCPP_INFO(this->get_logger(), "IN **ON_DEACTIVATE**");
+            rclcpp_lifecycle::LifecycleNode::on_deactivate(previous_state);
+
+            return LCR::SUCCESS;
+        };
+
+        LCR on_cleanup(const rclcpp_lifecycle::State &previous_state) {
+            (void)previous_state;
+            RCLCPP_INFO(this->get_logger(), "IN **ON_CLEANUP**");
+
+            return LCR::SUCCESS;
+        };
+
+        LCR on_shutdown(const rclcpp_lifecycle::State &previous_state) {
+            (void)previous_state;
+            RCLCPP_INFO(this->get_logger(), "IN **ON_SHUTDOWN**");
+
+            return LCR::SUCCESS;
+        };
+
+    private:
+
+};
+
+int main(int argc, char **argv) {
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<lifecycle_planner>();
+    rclcpp::spin(node->get_node_base_interface());
+    rclcpp::shutdown();
+    return 0; 
+}

--- a/src/ur10_planner/src/lifecycle_planner.cpp
+++ b/src/ur10_planner/src/lifecycle_planner.cpp
@@ -1,0 +1,140 @@
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+// moveit includes
+#include <moveit/move_group_interface/move_group_interface.hpp>
+#include <moveit/planning_scene_interface/planning_scene_interface.hpp>
+
+#include <moveit_msgs/msg/display_robot_state.hpp>
+#include <moveit_msgs/msg/display_trajectory.hpp>
+
+#include <moveit_msgs/msg/attached_collision_object.hpp>
+#include <moveit_msgs/msg/collision_object.hpp>
+
+#include <moveit_visual_tools/moveit_visual_tools.h>
+
+// LCR = Lifecycle Callback Return
+using LCR = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("lifecycle_planner_logger");
+namespace rvt = rviz_visual_tools;
+
+
+
+class lifecycle_planner : public rclcpp_lifecycle::LifecycleNode {
+    public:
+        lifecycle_planner(): LifecycleNode("lifecycle_planner") {
+            RCLCPP_INFO(this->get_logger(), "In constructor ... waiting for next step");
+        }
+
+        LCR on_configure(const rclcpp_lifecycle::State &previous_state) {
+            (void)previous_state;
+            RCLCPP_INFO(LOGGER, "IN **ON_CONFIGURE**");
+            static const std::string PLANNING_GROUP = "arm";
+
+            auto node_ptr = std::dynamic_pointer_cast<rclcpp::Node>(this->shared_from_this());
+
+            move_group = std::make_shared<moveit::planning_interface::MoveGroupInterface>(node_ptr, PLANNING_GROUP);            
+            planning_scene_interface = std::make_shared<moveit::planning_interface::PlanningSceneInterface>();
+
+            // initialize visualization 
+
+            visual_tools = std::make_shared<moveit_visual_tools::MoveItVisualTools>(node_ptr,"/world", "published_markers", move_group->getRobotModel());
+            visual_tools->deleteAllMarkers();
+
+            visual_tools->loadRemoteControl();
+
+            text_pose.translation().z() = 1.0;
+            visual_tools->publishText(text_pose, "lifecycle_planner (may need to change)", rvt::WHITE, rvt::XLARGE);
+
+            visual_tools->trigger();
+
+            // log info
+
+            RCLCPP_INFO(LOGGER, "Ur10 planning frame          : %s", move_group->getPlanningFrame().c_str());
+            RCLCPP_INFO(LOGGER, "Ur10 end effector link       : %s", move_group->getEndEffectorLink().c_str());
+            RCLCPP_INFO(LOGGER, "All available planning groups: ");
+            std::copy(move_group->getJointModelGroupNames().begin(), move_group->getJointModelGroupNames().end(),
+                std::ostream_iterator<std::string>(std::cout, ", "));
+
+            return LCR::SUCCESS;
+        };
+
+        LCR on_activate(const rclcpp_lifecycle::State &previous_state) {
+            RCLCPP_INFO(LOGGER, "IN **ON_ACTIVATE**");
+            rclcpp_lifecycle::LifecycleNode::on_activate(previous_state);
+            
+            // planning to a pose goal
+
+            visual_tools->prompt("Press 'next' in the RvizVisualToolsGui window to start");
+
+            // set example pose 
+            // TODO : write a function where we can parse different poses (points) and create a sudo "welding" path
+            target_pose.position = move_group->getCurrentPose().pose.position;
+            target_pose.orientation = move_group->getCurrentPose().pose.orientation;
+            target_pose.position.x = move_group->getCurrentPose().pose.position.x + 1;
+            
+            move_group->setPoseTarget(target_pose);
+
+            moveit::planning_interface::MoveGroupInterface::Plan plan;
+
+            bool success = (move_group->plan(plan) == moveit::core::MoveItErrorCode::SUCCESS);
+
+            RCLCPP_INFO(LOGGER, "Visualizing plan (pose goal) %s", success ? "" : "FAILED");
+
+            // visualizing plan
+
+            RCLCPP_INFO(LOGGER, "Visualizing plan as trajectory line");
+
+            // raw pointer to refer to the planning group
+            static const std::string PLANNING_GROUP = "arm";
+            const moveit::core::JointModelGroup* joint_model_group = move_group->getCurrentState()->getJointModelGroup(PLANNING_GROUP);
+
+            visual_tools->publishAxisLabeled(target_pose, "test_pose");
+            visual_tools->publishText(text_pose, "pose_goal", rvt::WHITE, rvt::XLARGE);
+            visual_tools->publishTrajectoryLine(plan.trajectory, joint_model_group);
+            visual_tools->trigger();
+
+            return LCR::SUCCESS;
+        };
+
+        LCR on_deactivate(const rclcpp_lifecycle::State &previous_state) {
+            RCLCPP_INFO(this->get_logger(), "IN **ON_DEACTIVATE**");
+            rclcpp_lifecycle::LifecycleNode::on_deactivate(previous_state);
+
+            return LCR::SUCCESS;
+        };
+
+        LCR on_cleanup(const rclcpp_lifecycle::State &previous_state) {
+            (void)previous_state;
+            RCLCPP_INFO(this->get_logger(), "IN **ON_CLEANUP**");
+
+            return LCR::SUCCESS;
+        };
+
+        LCR on_shutdown(const rclcpp_lifecycle::State &previous_state) {
+            (void)previous_state;
+            RCLCPP_INFO(this->get_logger(), "IN **ON_SHUTDOWN**");
+
+            return LCR::SUCCESS;
+        };
+
+    private:
+        std::shared_ptr<moveit::planning_interface::MoveGroupInterface> move_group;
+        std::shared_ptr<moveit_visual_tools::MoveItVisualTools> visual_tools;
+        // class to add and remove collision object in our scene
+        std::shared_ptr<moveit::planning_interface::PlanningSceneInterface> planning_scene_interface;
+
+        Eigen::Isometry3d text_pose = Eigen::Isometry3d::Identity();
+
+        geometry_msgs::msg::Pose target_pose;
+
+};
+
+int main(int argc, char **argv) {
+    rclcpp::init(argc, argv);
+
+    auto node = std::make_shared<lifecycle_planner>();
+    rclcpp::spin(node->get_node_base_interface());
+    rclcpp::shutdown();
+    return 0; 
+}

--- a/src/ur10_planner/src/lifecycle_planner.cpp
+++ b/src/ur10_planner/src/lifecycle_planner.cpp
@@ -1,106 +1,143 @@
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
+// ros2
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+
+// c++
+#include <thread>
 
 // moveit includes
 #include <moveit/move_group_interface/move_group_interface.hpp>
 #include <moveit/planning_scene_interface/planning_scene_interface.hpp>
+#include <moveit_visual_tools/moveit_visual_tools.h>
 
+// moveit msgs
 #include <moveit_msgs/msg/display_robot_state.hpp>
 #include <moveit_msgs/msg/display_trajectory.hpp>
-
 #include <moveit_msgs/msg/attached_collision_object.hpp>
 #include <moveit_msgs/msg/collision_object.hpp>
 
-#include <moveit_visual_tools/moveit_visual_tools.h>
-
 // LCR = Lifecycle Callback Return
 using LCR = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("lifecycle_planner_logger");
 namespace rvt = rviz_visual_tools;
-
 
 
 class lifecycle_planner : public rclcpp_lifecycle::LifecycleNode {
     public:
-        lifecycle_planner(): LifecycleNode("lifecycle_planner") {
+        lifecycle_planner(const rclcpp::NodeOptions & options) : 
+        LifecycleNode("lifecycle_planner", options),
+        PLANNING_GROUP("arm"),
+        END_EFFECTOR("welding_torch_end_effector")
+        {
             RCLCPP_INFO(this->get_logger(), "In constructor ... waiting for next step");
         }
 
         LCR on_configure(const rclcpp_lifecycle::State &previous_state) {
             (void)previous_state;
-            RCLCPP_INFO(LOGGER, "IN **ON_CONFIGURE**");
-            static const std::string PLANNING_GROUP = "arm";
+            RCLCPP_INFO(this->get_logger(), "IN **ON_CONFIGURE**");
+            
+            // create and start moveit node 
+            // moveit rquires a regular rclcpp::Node, not a rclcpp_lifecycle::LifecycleNode, so we create a new node
+            // then we spin this regular node own its own thread. We then pass in the options from the lifecycle node
+            // which is how the regular node gets all the moveit parameters.
+            auto node_options = this->get_node_options();
+            moveit_node = std::make_shared<rclcpp::Node>("lifecycle_planner_moveit_node", node_options);
 
-            auto node_ptr = std::dynamic_pointer_cast<rclcpp::Node>(this->shared_from_this());
+            executor_thread = std::thread([this]() {
+                this->executor.add_node(this->moveit_node);
+                this->executor.spin();
+            });
+            RCLCPP_INFO(this->get_logger(), "MoveIt node thread started");
 
-            move_group = std::make_shared<moveit::planning_interface::MoveGroupInterface>(node_ptr, PLANNING_GROUP);            
+            // start and check MoveGroupInterface initialization
+            move_group = std::make_shared<moveit::planning_interface::MoveGroupInterface>(moveit_node, PLANNING_GROUP);
+            if(!move_group) {
+                RCLCPP_FATAL(this->get_logger(), "FAILED to initialize MoveGroupInterface class");
+                return LCR::FAILURE;
+            }            
+            RCLCPP_INFO(this->get_logger(), "SUCCESS initializing MoveGroupInterface class");
+            
+            // check for a valid robot model
+            if(!move_group->getRobotModel()) {
+                RCLCPP_FATAL(this->get_logger(), "FAILED to get robot model");
+                return LCR::FAILURE;
+            }
+            RCLCPP_INFO(this->get_logger(), "SUCCESS retreiving robot model");
+
+            // set the end effector from the robots SRDF
+            move_group->setEndEffector(END_EFFECTOR);
+
+            // initialize planning scene and visual tools
             planning_scene_interface = std::make_shared<moveit::planning_interface::PlanningSceneInterface>();
+            visual_tools = std::make_shared<moveit_visual_tools::MoveItVisualTools>(moveit_node,"/world", "published_markers", move_group->getRobotModel());
 
-            // initialize visualization 
-
-            visual_tools = std::make_shared<moveit_visual_tools::MoveItVisualTools>(node_ptr,"/world", "published_markers", move_group->getRobotModel());
             visual_tools->deleteAllMarkers();
-
             visual_tools->loadRemoteControl();
 
-            text_pose.translation().z() = 1.0;
-            visual_tools->publishText(text_pose, "lifecycle_planner (may need to change)", rvt::WHITE, rvt::XLARGE);
-
+            text_pose.translation().z() = 2.0;
+            visual_tools->publishText(text_pose, "lifecycle_planner : Configured", rvt::WHITE, rvt::XXLARGE);
             visual_tools->trigger();
 
             // log info
-
-            RCLCPP_INFO(LOGGER, "Ur10 planning frame          : %s", move_group->getPlanningFrame().c_str());
-            RCLCPP_INFO(LOGGER, "Ur10 end effector link       : %s", move_group->getEndEffectorLink().c_str());
-            RCLCPP_INFO(LOGGER, "All available planning groups: ");
-            std::copy(move_group->getJointModelGroupNames().begin(), move_group->getJointModelGroupNames().end(),
-                std::ostream_iterator<std::string>(std::cout, ", "));
+            RCLCPP_INFO(this->get_logger(), "Ur10 planning frame: %s", move_group->getPlanningFrame().c_str());
+            RCLCPP_INFO(this->get_logger(), "Ur10 end effector link: %s", move_group->getEndEffectorLink().c_str());
+            RCLCPP_INFO(this->get_logger(), "Configuration successful, ready to move to activate");
 
             return LCR::SUCCESS;
         };
 
         LCR on_activate(const rclcpp_lifecycle::State &previous_state) {
-            RCLCPP_INFO(LOGGER, "IN **ON_ACTIVATE**");
+            RCLCPP_INFO(this->get_logger(), "IN **ON_ACTIVATE**");
             rclcpp_lifecycle::LifecycleNode::on_activate(previous_state);
+            moveit::planning_interface::MoveGroupInterface::Plan plan;
             
-            // planning to a pose goal
-
             visual_tools->prompt("Press 'next' in the RvizVisualToolsGui window to start");
 
-            // set example pose 
-            // TODO : write a function where we can parse different poses (points) and create a sudo "welding" path
-            target_pose.position = move_group->getCurrentPose().pose.position;
-            target_pose.orientation = move_group->getCurrentPose().pose.orientation;
-            target_pose.position.x = move_group->getCurrentPose().pose.position.x + 1;
-            
+            // set target pose
+            //target_pose.position = move_group->getCurrentPose().pose.position;
+            //target_pose.orientation = move_group->getCurrentPose().pose.orientation;
+            //target_pose.position.x = move_group->getCurrentPose().pose.position.x + 0.5;
+            //target_pose.position.y = move_group->getCurrentPose().pose.position.y + 0.8;
+            //target_pose.position.z = move_group->getCurrentPose().pose.position.z + 0.6;
+            target_pose = move_group->getCurrentPose().pose;
+            target_pose.position.x += 0.5;
+            target_pose.position.z += 0.3;
+
             move_group->setPoseTarget(target_pose);
 
-            moveit::planning_interface::MoveGroupInterface::Plan plan;
-
+            // plan out
             bool success = (move_group->plan(plan) == moveit::core::MoveItErrorCode::SUCCESS);
+            RCLCPP_INFO(this->get_logger(), "Visualizing plan (pose goal) %s", success ? "" : "FAILED");
 
-            RCLCPP_INFO(LOGGER, "Visualizing plan (pose goal) %s", success ? "" : "FAILED");
+            if(!success) {
+                return LCR::FAILURE;
+            }
 
             // visualizing plan
-
-            RCLCPP_INFO(LOGGER, "Visualizing plan as trajectory line");
-
-            // raw pointer to refer to the planning group
-            static const std::string PLANNING_GROUP = "arm";
+            RCLCPP_INFO(this->get_logger(), "Visualizing plan as trajectory line");
+            const std::string ee_link_name = move_group->getEndEffectorLink();
+            const moveit::core::LinkModel* ee_link_model = move_group->getRobotModel()->getLinkModel(ee_link_name);
             const moveit::core::JointModelGroup* joint_model_group = move_group->getCurrentState()->getJointModelGroup(PLANNING_GROUP);
 
             visual_tools->publishAxisLabeled(target_pose, "test_pose");
             visual_tools->publishText(text_pose, "pose_goal", rvt::WHITE, rvt::XLARGE);
-            visual_tools->publishTrajectoryLine(plan.trajectory, joint_model_group);
+            visual_tools->publishTrajectoryLine(plan.trajectory, ee_link_model, joint_model_group);
             visual_tools->trigger();
+
+            // execute plan
+            visual_tools->prompt("Press 'next' in the RvizVisualToolsGui window to move the robot along visualized trajectory");
+            move_group->move();
 
             return LCR::SUCCESS;
         };
 
         LCR on_deactivate(const rclcpp_lifecycle::State &previous_state) {
             RCLCPP_INFO(this->get_logger(), "IN **ON_DEACTIVATE**");
-            rclcpp_lifecycle::LifecycleNode::on_deactivate(previous_state);
 
+            if(move_group) {
+                move_group->stop();
+            }
+
+            rclcpp_lifecycle::LifecycleNode::on_deactivate(previous_state);
             return LCR::SUCCESS;
         };
 
@@ -108,33 +145,58 @@ class lifecycle_planner : public rclcpp_lifecycle::LifecycleNode {
             (void)previous_state;
             RCLCPP_INFO(this->get_logger(), "IN **ON_CLEANUP**");
 
+            // stop executor
+            executor.cancel();
+
+            // join thread
+            // join the thread and wait for it to finish executing
+            if(executor_thread.joinable()) {
+                executor_thread.join();
+            }
+
+            // reset smart pointers
+            move_group.reset();
+            planning_scene_interface.reset();
+            visual_tools.reset();
+            moveit_node.reset();
+
+            RCLCPP_INFO(this->get_logger(), "SUCCESSFUL cleanup");
             return LCR::SUCCESS;
         };
 
         LCR on_shutdown(const rclcpp_lifecycle::State &previous_state) {
-            (void)previous_state;
             RCLCPP_INFO(this->get_logger(), "IN **ON_SHUTDOWN**");
-
-            return LCR::SUCCESS;
+            return on_cleanup(previous_state);
         };
 
     private:
+        // configuration variables
+        const std::string PLANNING_GROUP;
+        const std::string END_EFFECTOR;
+
+        // moveit
         std::shared_ptr<moveit::planning_interface::MoveGroupInterface> move_group;
-        std::shared_ptr<moveit_visual_tools::MoveItVisualTools> visual_tools;
-        // class to add and remove collision object in our scene
         std::shared_ptr<moveit::planning_interface::PlanningSceneInterface> planning_scene_interface;
+        std::shared_ptr<moveit_visual_tools::MoveItVisualTools> visual_tools;
+
+        // thread
+        rclcpp::Node::SharedPtr moveit_node;
+        rclcpp::executors::SingleThreadedExecutor executor;
+        std::thread executor_thread;
 
         Eigen::Isometry3d text_pose = Eigen::Isometry3d::Identity();
-
         geometry_msgs::msg::Pose target_pose;
-
 };
 
 int main(int argc, char **argv) {
     rclcpp::init(argc, argv);
 
-    auto node = std::make_shared<lifecycle_planner>();
+    // allow parameters from launch file to be loaded
+    auto options = rclcpp::NodeOptions().automatically_declare_parameters_from_overrides(true);
+    auto node = std::make_shared<lifecycle_planner>(options);
+
     rclcpp::spin(node->get_node_base_interface());
+
     rclcpp::shutdown();
     return 0; 
 }


### PR DESCRIPTION
## Description

This pull request introduces a new ROS 2 node, `lifecycle_planner`, which integrates MoveIt 2 planning and execution into the ROS 2 lifecycle framework.

This allows the robot's planning capabilities to be externally managed (configured, activated, deactivated, and cleaned up) by a state manager, improving system robustness and startup.

Additionally the execution part of this should only be temporary. Its only included to test out the planner.

## Output
![2025-10-3023-45-25-ezgif com-optimize](https://github.com/user-attachments/assets/072be0ef-bf23-4d20-baf1-3ee7a2b3b427)

## How To Test

1.  Build the workspace: `colcon build`
2.  Source the workspace: `source install/setup.bash`
3.  Run the main robot launch file (which includes this `lifecycle_planner_node`).
4.  In a separate terminal, transition the node to the `configuring` state:
    ```bash
    ros2 lifecycle set /lifecycle_planner configure
    ```
5.  Transition the node to the `activating` state:
    ```bash
    ros2 lifecycle set /lifecycle_planner activate
    ```
6.  In RViz, go to the "RvizVisualToolsGui" panel and click "next".
    * **Check:** The node should log "Visualizing plan" and a trajectory line should appear in RViz.
7.  Click "next" again.
    * **Check:** The robot should execute the planned motion in Gazebo and RViz.
8. Test deactivation and cleanup:
    ```bash
    ros2 lifecycle set /lifecycle_planner deactivate
    ```
   ```bash
    ros2 lifecycle set /lifecycle_planner cleanup
    ```